### PR TITLE
allow any iterable of strings

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 
 from schema import And, Optional, Or, Schema
 
-from Utils import get_fuzzy_results
+from Utils import get_fuzzy_results, is_iterable_of_str
 
 if typing.TYPE_CHECKING:
     from BaseClasses import PlandoOptions
@@ -766,7 +766,7 @@ class VerifyKeys(metaclass=FreezeValidKeys):
     value: typing.Any
 
     @classmethod
-    def verify_keys(cls, data: typing.List[str]):
+    def verify_keys(cls, data: typing.Iterable[str]):
         if cls.valid_keys:
             data = set(data)
             dataset = set(word.casefold() for word in data) if cls.valid_keys_casefold else set(data)
@@ -857,7 +857,7 @@ class OptionList(Option[typing.List[typing.Any]], VerifyKeys):
 
     @classmethod
     def from_any(cls, data: typing.Any):
-        if isinstance(data, (list, set, frozenset, tuple)):
+        if is_iterable_of_str(data):
             cls.verify_keys(data)
             return cls(data)
         return cls.from_text(str(data))
@@ -883,7 +883,7 @@ class OptionSet(Option[typing.Set[str]], VerifyKeys):
 
     @classmethod
     def from_any(cls, data: typing.Any):
-        if isinstance(data, (list, set, frozenset, tuple)):
+        if is_iterable_of_str(data):
             cls.verify_keys(data)
             return cls(data)
         return cls.from_text(str(data))

--- a/Utils.py
+++ b/Utils.py
@@ -19,6 +19,7 @@ import warnings
 from argparse import Namespace
 from settings import Settings, get_settings
 from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union
+from typing_extensions import TypeGuard
 from yaml import load, load_all, dump
 
 try:
@@ -966,3 +967,13 @@ class RepeatableChain:
 
     def __len__(self):
         return sum(len(iterable) for iterable in self.iterable)
+
+
+def is_iterable_of_str(obj: object) -> TypeGuard[typing.Iterable[str]]:
+    """ but not a `str` (because technically, `str` is `Iterable[str]`) """
+    if isinstance(obj, str):
+        return False
+    if not isinstance(obj, typing.Iterable):
+        return False
+    obj_it: typing.Iterable[object] = obj
+    return all(isinstance(v, str) for v in obj_it)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ certifi>=2023.11.17
 cython>=3.0.8
 cymem>=2.0.8
 orjson>=3.9.10
+typing-extensions>=4.7.0


### PR DESCRIPTION
## What is this fixing or adding?

Do we want to allow any iterable of strings?

Note that typing-extensions isn't a new dependency. It's already a dependency of other packages we depend on. It's just better to be explicit if we use it directly (in case we remove the other dependencies that depend on it).

## How was this tested?

just unit tests